### PR TITLE
Check for ack at the start of the rename script

### DIFF
--- a/rename_phoenix_project.sh
+++ b/rename_phoenix_project.sh
@@ -6,6 +6,12 @@
 
 set -e
 
+if ! command -v ack &> /dev/null
+then
+    echo "\`ack\` could not be found. Please install it before continuing"
+    exit 1
+fi
+
 CURRENT_NAME="PetalBoiletplate"
 CURRENT_OTP="petal_boilerplate"
 


### PR DESCRIPTION
`ack` wasn't installed on my Mac. I figure others may run into this, so a helpful message is warranted.