### PR TITLE
Remove test/CURRENT_OTP from the script as it does not exists

### DIFF
--- a/rename_phoenix_project.sh
+++ b/rename_phoenix_project.sh
@@ -20,5 +20,4 @@ git mv lib/$CURRENT_OTP lib/$NEW_OTP
 git mv lib/$CURRENT_OTP.ex lib/$NEW_OTP.ex
 git mv lib/${CURRENT_OTP}_web lib/${NEW_OTP}_web
 git mv lib/${CURRENT_OTP}_web.ex lib/${NEW_OTP}_web.ex
-git mv test/$CURRENT_OTP test/$NEW_OTP
 git mv test/${CURRENT_OTP}_web test/${NEW_OTP}_web


### PR DESCRIPTION
The directory `test/$CURRENT_OTP` doesn't exist in the current state of the template, so the rename script was failing here.