### PR TITLE
Fix `mix assets.deploy`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,7 @@ defmodule PetalBoilerplate.MixProject do
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
       "assets.deploy": [
-        "cmd --cd assets npm run deploy",
+        "tailwind default --minify",
         "esbuild default --minify",
         "phx.digest"
       ]


### PR DESCRIPTION
- there is no `package.json` in `assets` so there is no `deploy` npm script
- running tailwind is needed to produce CSS assets